### PR TITLE
Bug fix in response of chem_env

### DIFF
--- a/discus/prog/chem.f90
+++ b/discus/prog/chem.f90
@@ -654,7 +654,7 @@ SUBROUTINE chem
  4620 FORMAT (   37x,'neighbours   : ',15I4,/) 
  4700 FORMAT (/,'    Defined correlation ranges: ',/) 
  4710 FORMAT ('       Correlation range ',i3,': ',                      &
-     &        3(F7.3,2x),'+-',F7.3,' A  +-',F7.3,'ø')                   
+     &        3(F7.3,2x),'+-',F7.3,' A  +-',F7.3,'Ã¸')                   
  4720 FORMAT ('            central atom    ',' ALL') 
  4730 FORMAT ('            central atom    ',50I4) 
  4740 FORMAT ('            neigh.  atom    ',' ALL') 
@@ -1928,7 +1928,7 @@ ENDIF
          at_name_i = at_name (cr_iscat (atom_env (ianz) ) ) 
          CALL indextocell (atom_env (ianz), icell, isite) 
          WRITE (output_io, 1400) ianz, atom_env (ianz), at_name_i,      &
-         res_para (ianz), (cr_pos (i, atom_env (ianz) ), i = 1, 3),     &
+         atom_dis (ianz), (cr_pos (i, atom_env (ianz) ), i = 1, 3),     &
          icell, isite                                                   
          res_para (ianz) = float (atom_env (ianz) ) 
          ENDDO 


### PR DESCRIPTION
chem_env was returning the list of indices, atom types and positions after sorting by nearest neighbour distance, while the list of distances itself was unsorted.