### PR TITLE
Fix missing variable declarations in discus/prog/four_strucf_mod

### DIFF
--- a/discus/prog/four_strucf_mod.f90
+++ b/discus/prog/four_strucf_mod.f90
@@ -40,6 +40,8 @@ INTEGER (KIND=PREC_INT_LARGE), PARAMETER :: shift = -6
 INTEGER (KIND=PREC_INT_LARGE)   :: num23,num123, num123_1
 !
 INTEGER :: IAND, ISHFT
+INTEGER :: ALLOC_STAT
+INTERGER :: L, M, N
 !
 ! Neder's original code
 !


### PR DESCRIPTION
fixes a build error with 6.16.00